### PR TITLE
AutoWire attribute support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /vendor/
 .idea
-.phpunit.result.cache
+.phpunit.cache

--- a/src/Helper/Attribute/ConfigureAttribute.php
+++ b/src/Helper/Attribute/ConfigureAttribute.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Stefna\DependencyInjection\Helper\Attribute;
+
+use Psr\Container\ContainerInterface;
+
+interface ConfigureAttribute
+{
+	public function configure(object $object, ContainerInterface $container): object;
+}

--- a/src/Helper/Attribute/ResolverAttribute.php
+++ b/src/Helper/Attribute/ResolverAttribute.php
@@ -6,10 +6,5 @@ use Psr\Container\ContainerInterface;
 
 interface ResolverAttribute
 {
-	/**
-	 * @template T
-	 * @param class-string<T> $type
-	 * @return T
-	 */
-	public function resolve(string $type, ContainerInterface $container);
+	public function resolve(string $type, ContainerInterface $container): mixed;
 }

--- a/src/Helper/Attribute/ResolverAttribute.php
+++ b/src/Helper/Attribute/ResolverAttribute.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Stefna\DependencyInjection\Helper\Attribute;
+
+use Psr\Container\ContainerInterface;
+
+interface ResolverAttribute
+{
+	/**
+	 * @template T
+	 * @param class-string<T> $type
+	 * @return T
+	 */
+	public function resolve(string $type, ContainerInterface $container);
+}

--- a/src/Helper/Autowire.php
+++ b/src/Helper/Autowire.php
@@ -52,6 +52,9 @@ final class Autowire
 			}
 
 			if (!$paramInstance && $type->isBuiltin()) {
+				if ($param->isOptional()) {
+					continue;
+				}
 				throw new \BadMethodCallException('Can\'t autowire native types');
 			}
 

--- a/tests/Helper/AutowireTest.php
+++ b/tests/Helper/AutowireTest.php
@@ -14,6 +14,7 @@ use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithAttribute2;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithAttribute3;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithAttribute4;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithDefaultArgs;
+use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithNativeDefaultArgs;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithoutArgs;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithScalarArgs;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithUnionType;
@@ -134,6 +135,15 @@ final class AutowireTest extends TestCase
 		$object = $autowire($this->container(), TestWithAttribute4::class);
 		$this->assertInstanceOf(TestWithAttribute4::class, $object);
 		$this->assertSame('42', $object->test);
+	}
+
+	public function testAutoWireNativeTypeWithDefaultValue(): void
+	{
+		$autowire = Autowire::cls();
+
+		$object = $autowire($this->container(), TestWithNativeDefaultArgs::class);
+		$this->assertInstanceOf(TestWithNativeDefaultArgs::class, $object);
+		$this->assertSame([], $object->memory);
 	}
 
 	/**

--- a/tests/Helper/AutowireTest.php
+++ b/tests/Helper/AutowireTest.php
@@ -12,6 +12,7 @@ use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithArgs;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithAttribute1;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithAttribute2;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithAttribute3;
+use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithAttribute4;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithDefaultArgs;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithoutArgs;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithScalarArgs;
@@ -47,7 +48,7 @@ final class AutowireTest extends TestCase
 		$this->assertInstanceOf(TestWithDefaultArgs::class, $object);
 	}
 
-	public function testAutowireWithDefaultArgumentOverride(): void
+	public function testAutoWireWithDefaultArgumentOverride(): void
 	{
 		$autowire = Autowire::cls();
 
@@ -124,6 +125,15 @@ final class AutowireTest extends TestCase
 		$this->assertInstanceOf(TestWithAttribute3::class, $object);
 		$this->assertInstanceOf(TestResolveAndConfigure::class, $object->test);
 		$this->assertSame('42', $object->test->value);
+	}
+
+	public function testAutoWireWithResolveScalarValue(): void
+	{
+		$autowire = Autowire::cls();
+
+		$object = $autowire($this->container(), TestWithAttribute4::class);
+		$this->assertInstanceOf(TestWithAttribute4::class, $object);
+		$this->assertSame('42', $object->test);
 	}
 
 	/**

--- a/tests/Helper/AutowireTest.php
+++ b/tests/Helper/AutowireTest.php
@@ -6,7 +6,12 @@ use Stefna\DependencyInjection\Container;
 use Stefna\DependencyInjection\Definition\DefinitionArray;
 use Stefna\DependencyInjection\Helper\Autowire;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestInterface;
+use Stefna\DependencyInjection\Tests\Helper\Stubs\TestResolveAndConfigure;
+use Stefna\DependencyInjection\Tests\Helper\Stubs\TestResolveInterface;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithArgs;
+use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithAttribute1;
+use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithAttribute2;
+use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithAttribute3;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithDefaultArgs;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithoutArgs;
 use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithScalarArgs;
@@ -83,6 +88,42 @@ final class AutowireTest extends TestCase
 		$this->expectExceptionMessage('Can\'t autowire complex types');
 
 		$autowire($this->container(), TestWithUnionType::class);
+	}
+
+	public function testAutoWireWithAttributeResolver(): void
+	{
+		$autowire = Autowire::cls();
+
+		$object = $autowire($this->container([
+			TestInterface::class => fn () => new TestWithScalarArgs(true),
+		]), TestWithAttribute1::class);
+		$this->assertInstanceOf(TestWithAttribute1::class, $object);
+		$this->assertInstanceOf(TestWithArgs::class, $object->testArgs);
+		$this->assertInstanceOf(TestWithDefaultArgs::class, $object->testDefault);
+		$this->assertInstanceOf(TestWithScalarArgs::class, $object->testFallback);
+	}
+
+	public function testAutoWireWithAttributeConfigure(): void
+	{
+		$autowire = Autowire::cls();
+
+		$object = $autowire($this->container([
+			TestResolveAndConfigure::class => fn () => new TestResolveAndConfigure('1'),
+		]), TestWithAttribute2::class);
+		$this->assertInstanceOf(TestWithAttribute2::class, $object);
+		$this->assertSame('5', $object->test->value);
+	}
+
+	public function testAutoWireWithResolveAndConfigure(): void
+	{
+		$autowire = Autowire::cls();
+
+		$object = $autowire($this->container([
+			TestResolveInterface::class => fn () => new TestResolveAndConfigure('1'),
+		]), TestWithAttribute3::class);
+		$this->assertInstanceOf(TestWithAttribute3::class, $object);
+		$this->assertInstanceOf(TestResolveAndConfigure::class, $object->test);
+		$this->assertSame('42', $object->test->value);
 	}
 
 	/**

--- a/tests/Helper/Stubs/Attribute/TestConfigureAttribute.php
+++ b/tests/Helper/Stubs/Attribute/TestConfigureAttribute.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Stefna\DependencyInjection\Tests\Helper\Stubs\Attribute;
+
+use Psr\Container\ContainerInterface;
+use Stefna\DependencyInjection\Helper\Attribute\ConfigureAttribute;
+use Stefna\DependencyInjection\Tests\Helper\Stubs\TestResolveAndConfigure;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final class TestConfigureAttribute implements ConfigureAttribute
+{
+	public function __construct(
+		public string $value,
+	) {}
+
+	public function configure(object $object, ContainerInterface $container): object
+	{
+		if ($object instanceof TestResolveAndConfigure) {
+			$object->value = $this->value;
+		}
+
+		return $object;
+	}
+}

--- a/tests/Helper/Stubs/Attribute/TestCustomResolveAttribute.php
+++ b/tests/Helper/Stubs/Attribute/TestCustomResolveAttribute.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Stefna\DependencyInjection\Tests\Helper\Stubs\Attribute;
+
+use Psr\Container\ContainerInterface;
+use Stefna\DependencyInjection\Helper\Attribute\ConfigureAttribute;
+use Stefna\DependencyInjection\Helper\Attribute\ResolverAttribute;
+use Stefna\DependencyInjection\Tests\Helper\Stubs\TestResolveAndConfigure;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final class TestCustomResolveAttribute implements ResolverAttribute
+{
+	public function resolve(string $type, ContainerInterface $container)
+	{
+		return new TestResolveAndConfigure('2');
+	}
+}

--- a/tests/Helper/Stubs/Attribute/TestResolveAttribute.php
+++ b/tests/Helper/Stubs/Attribute/TestResolveAttribute.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Stefna\DependencyInjection\Tests\Helper\Stubs\Attribute;
+
+use Psr\Container\ContainerInterface;
+use Stefna\DependencyInjection\Helper\Attribute\ResolverAttribute;
+use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithArgs;
+use Stefna\DependencyInjection\Tests\Helper\Stubs\TestWithDefaultArgs;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final class TestResolveAttribute implements ResolverAttribute
+{
+	public function __construct(
+		private string $type,
+	) {}
+
+	public function resolve(string $type, ContainerInterface $container)
+	{
+		$date = new \DateTimeImmutable();
+		return match($this->type) {
+			'args' => new TestWithArgs($date),
+			'default' => new TestWithDefaultArgs(),
+			default => null,
+		};
+	}
+}

--- a/tests/Helper/Stubs/Attribute/TestResolveAttribute.php
+++ b/tests/Helper/Stubs/Attribute/TestResolveAttribute.php
@@ -14,10 +14,10 @@ final class TestResolveAttribute implements ResolverAttribute
 		private string $type,
 	) {}
 
-	public function resolve(string $type, ContainerInterface $container)
+	public function resolve(string $type, ContainerInterface $container): mixed
 	{
 		$date = new \DateTimeImmutable();
-		return match($this->type) {
+		return match ($this->type) {
 			'args' => new TestWithArgs($date),
 			'default' => new TestWithDefaultArgs(),
 			default => null,

--- a/tests/Helper/Stubs/Attribute/TestResolveScalarValue.php
+++ b/tests/Helper/Stubs/Attribute/TestResolveScalarValue.php
@@ -3,15 +3,17 @@
 namespace Stefna\DependencyInjection\Tests\Helper\Stubs\Attribute;
 
 use Psr\Container\ContainerInterface;
-use Stefna\DependencyInjection\Helper\Attribute\ConfigureAttribute;
 use Stefna\DependencyInjection\Helper\Attribute\ResolverAttribute;
-use Stefna\DependencyInjection\Tests\Helper\Stubs\TestResolveAndConfigure;
 
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
-final class TestCustomResolveAttribute implements ResolverAttribute
+final class TestResolveScalarValue implements ResolverAttribute
 {
+	public function __construct(
+		private string $value,
+	) {}
+
 	public function resolve(string $type, ContainerInterface $container): mixed
 	{
-		return new TestResolveAndConfigure('2');
+		return $this->value;
 	}
 }

--- a/tests/Helper/Stubs/TestResolveAndConfigure.php
+++ b/tests/Helper/Stubs/TestResolveAndConfigure.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Stefna\DependencyInjection\Tests\Helper\Stubs;
+
+final class TestResolveAndConfigure implements TestResolveInterface
+{
+	public function __construct(
+		public string $value,
+	) {}
+}

--- a/tests/Helper/Stubs/TestResolveInterface.php
+++ b/tests/Helper/Stubs/TestResolveInterface.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Stefna\DependencyInjection\Tests\Helper\Stubs;
+
+interface TestResolveInterface
+{
+}

--- a/tests/Helper/Stubs/TestWithAttribute1.php
+++ b/tests/Helper/Stubs/TestWithAttribute1.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Stefna\DependencyInjection\Tests\Helper\Stubs;
+
+use Stefna\DependencyInjection\Tests\Helper\Stubs\Attribute\TestResolveAttribute;
+
+final class TestWithAttribute1
+{
+	public function __construct(
+		#[TestResolveAttribute('args')]
+		public readonly TestInterface $testArgs,
+		#[TestResolveAttribute('default')]
+		public readonly TestInterface $testDefault,
+		#[TestResolveAttribute('unknown')]
+		public readonly TestInterface $testFallback,
+	) {}
+}

--- a/tests/Helper/Stubs/TestWithAttribute2.php
+++ b/tests/Helper/Stubs/TestWithAttribute2.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Stefna\DependencyInjection\Tests\Helper\Stubs;
+
+use Stefna\DependencyInjection\Tests\Helper\Stubs\Attribute\TestConfigureAttribute;
+
+final class TestWithAttribute2
+{
+	public function __construct(
+		#[TestConfigureAttribute('5')]
+		public readonly TestResolveAndConfigure $test,
+	) {}
+}

--- a/tests/Helper/Stubs/TestWithAttribute3.php
+++ b/tests/Helper/Stubs/TestWithAttribute3.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Stefna\DependencyInjection\Tests\Helper\Stubs;
+
+use Stefna\DependencyInjection\Tests\Helper\Stubs\Attribute\TestConfigureAttribute;
+use Stefna\DependencyInjection\Tests\Helper\Stubs\Attribute\TestCustomResolveAttribute;
+
+final class TestWithAttribute3
+{
+	public function __construct(
+		#[TestCustomResolveAttribute]
+		#[TestConfigureAttribute('42')]
+		public readonly TestResolveInterface $test,
+	) {}
+}

--- a/tests/Helper/Stubs/TestWithAttribute4.php
+++ b/tests/Helper/Stubs/TestWithAttribute4.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Stefna\DependencyInjection\Tests\Helper\Stubs;
+
+use Stefna\DependencyInjection\Tests\Helper\Stubs\Attribute\TestResolveScalarValue;
+
+final class TestWithAttribute4
+{
+	public function __construct(
+		#[TestResolveScalarValue('42')]
+		public readonly string $test,
+	) {}
+}

--- a/tests/Helper/Stubs/TestWithNativeDefaultArgs.php
+++ b/tests/Helper/Stubs/TestWithNativeDefaultArgs.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Stefna\DependencyInjection\Tests\Helper\Stubs;
+
+final class TestWithNativeDefaultArgs
+{
+	public function __construct(
+		public array $memory = [],
+	) {}
+}


### PR DESCRIPTION
Add support to modify and resolve parameters with attributes

This was mainly created to make it easier to configure log channels for the logger.
But also allows resolving of native values from example a config store